### PR TITLE
Add OpenSim UUID/password content delivery module and backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+php-app/vendor/
+php-app/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,1 +1,127 @@
-# 1-marketplace
+# OpenSimulator UUID/Password Content Delivery Add-on
+
+This repository provides a production-ready content delivery solution for OpenSimulator 9.3 consisting of:
+
+- **`UuidPasswordContentDeliveryModule`** – a C# `ISharedRegionModule` that authenticates avatar UUID/password pairs, proxies asset delivery, and integrates with the bundled PHP web service.
+- **PHP 8.2 web service** – exposes `/api/auth`, `/api/authorize`, and `/api/download` endpoints with strict validation, Argon2id password hashing, signed URLs, and rate limiting.
+- **Infrastructure assets** – migrations, configuration samples, automated tests, and documentation.
+
+## Repository Layout
+
+```
+opensim/                     # OpenSimulator module sources
+  PhpApiClient.cs            # Internal HTTP client with retries/backoff
+  UuidPasswordContentDeliveryModule.cs
+php-app/                     # PHP backend application
+  public/index.php           # Entry point/router
+  src/                       # PHP services (Auth, Authorize, Validator, etc.)
+  tests/                     # PHPUnit test suite
+migrations/001_init.sql      # MySQL schema and seed scaffold
+README.md                    # This document
+```
+
+## Building & Installing the OpenSim Module
+
+1. Copy `opensim/UuidPasswordContentDeliveryModule.cs` and `opensim/PhpApiClient.cs` into your OpenSim source tree (e.g. `OpenSim/Region/OptionalModules/`).
+2. Add the module name to your `OpenSim.ini`:
+
+   ```ini
+   [UuidPasswordContentDelivery]
+   Enabled = true
+   PhpApiBaseUrl = "https://content.example.com"
+   SharedSecret = "CHANGE_ME"
+   RequestTimeoutMs = 5000
+   MaxRetries = 2
+   ProxyBinary = false
+   RateLimitBackoffMs = 500
+   LoggingLevel = "INFO"
+   ```
+
+3. Rebuild OpenSim if required and restart the simulator. The module automatically registers `/content-delivery/auth-check` (health) and `/content-delivery/fetch` (content) handlers on each region.
+
+> **Note:** The module targets .NET 6.0 as required by OpenSim 9.3 and respects multi-region deployments.
+
+## Deploying the PHP Backend
+
+1. Install dependencies:
+
+   ```bash
+   cd php-app
+   composer install --no-dev --optimize-autoloader
+   ```
+
+2. Copy `.env.example` to `.env` and update the values:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   | Key | Description |
+   | --- | --- |
+   | `APP_BASE_URL` | Public HTTPS base URL (e.g. `https://content.example.com`). |
+   | `DB_*` | MySQL DSN/credentials. |
+   | `HMAC_SECRET` | Secret used to sign `/api/download` URLs. |
+   | `SHARED_SECRET` | Shared module secret (must match OpenSim `SharedSecret`). |
+   | `SIGNED_URL_TTL_SECONDS` | Signed URL lifetime (default 600s). |
+   | `TOKEN_TTL_SECONDS` | Authentication token lifetime (default 600s). |
+   | `RATE_LIMIT_PER_MINUTE` | Requests per minute per client. |
+   | `DOWNLOAD_STRATEGY` | `signed_url` (default) or `inline`. |
+   | `STORAGE_BASE_PATH` | Absolute path to on-disk asset store. |
+
+3. Apply the migration to your MySQL instance:
+
+   ```bash
+   mysql -u opensim -p opensim < migrations/001_init.sql
+   ```
+
+4. Configure your web server (nginx/Apache) to route HTTPS requests to `php-app/public/index.php` via PHP-FPM.
+
+5. Ensure TLS termination is active; the service rejects non-HTTPS requests when `FORCE_HTTPS=true`.
+
+## End-to-End Flow
+
+1. **Authenticate** – The module posts `{avatar_uuid, password}` to `/api/auth`. The PHP service validates credentials (Argon2id hashed passwords) and returns `{ok, token, expires_at}`.
+2. **Authorize** – The module posts `{token, request, id}` to `/api/authorize` to request an asset, inventory listing, or package. A successful response contains either `binary` content (base64) or a signed download URL.
+3. **Download** – When a signed URL is returned, the module either redirects the viewer or proxies the binary (configurable) by calling `/api/download?id=...&expires=...&sig=...`.
+
+## Example cURL Invocations
+
+```bash
+curl -sS https://content.example.com/api/auth \
+  -H 'Content-Type: application/json' \
+  -d '{"avatar_uuid":"123e4567-e89b-12d3-a456-426614174000","password":"CorrectHorseBatteryStaple"}'
+
+curl -sS https://content.example.com/api/authorize \
+  -H 'Content-Type: application/json' \
+  -d '{"token":"<token>","request":"asset","id":"123e4567-e89b-12d3-a456-426614174001"}'
+
+curl -L "https://content.example.com/api/download?id=123e4567-e89b-12d3-a456-426614174001&expires=<ts>&sig=<sig>"
+```
+
+## Testing
+
+Run the automated suites from the repository root:
+
+```bash
+# PHP unit tests
+(cd php-app && composer install && ./vendor/bin/phpunit)
+
+# .NET unit tests for PhpApiClient
+(dotnet test tests/cs/UuidPasswordContentDeliveryModule.Tests.csproj)
+```
+
+Both suites provide coverage for request validation, token issuance, signed URL generation, and HTTP client retry logic.
+
+## Security Considerations
+
+- UUIDs are validated client- and server-side.
+- Passwords are hashed with Argon2id; tokens are stored hashed and expire automatically.
+- Signed URLs use HMAC-SHA256 with configurable TTL.
+- PHP endpoints enforce per-client rate limiting and reject non-HTTPS requests in production.
+- The OpenSim module performs exponential backoff and structured logging with correlation IDs.
+
+## Maintenance
+
+- Update dependencies via `composer update` and `dotnet restore` as needed.
+- Rotate `HMAC_SECRET` periodically and sync with OpenSim configuration.
+- Purge expired tokens with a scheduled job (`DELETE FROM auth_tokens WHERE expires_at < NOW()`).

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,36 @@
+-- SPDX-License-Identifier: MIT
+CREATE TABLE users (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  avatar_uuid CHAR(36) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE assets (
+  id CHAR(36) PRIMARY KEY,
+  type ENUM('texture','notecard','object','sound','animation','other') NOT NULL DEFAULT 'other',
+  location VARCHAR(512) NOT NULL,
+  content_type VARCHAR(128) NOT NULL DEFAULT 'application/octet-stream',
+  filename VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE permissions (
+  user_id BIGINT NOT NULL,
+  asset_id CHAR(36) NOT NULL,
+  can_fetch TINYINT(1) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, asset_id),
+  CONSTRAINT fk_permissions_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT fk_permissions_asset FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE auth_tokens (
+  token CHAR(64) PRIMARY KEY,
+  user_id BIGINT NOT NULL,
+  expires_at DATETIME NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_auth_tokens_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_auth_tokens_user ON auth_tokens (user_id);

--- a/opensim/OpenSim.ini.sample
+++ b/opensim/OpenSim.ini.sample
@@ -1,0 +1,9 @@
+[UuidPasswordContentDelivery]
+Enabled = true
+PhpApiBaseUrl = "https://content.example.com"
+SharedSecret = "CHANGE_ME"
+RequestTimeoutMs = 5000
+MaxRetries = 2
+ProxyBinary = false
+RateLimitBackoffMs = 500
+LoggingLevel = "INFO"

--- a/opensim/PhpApiClient.cs
+++ b/opensim/PhpApiClient.cs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using log4net;
+
+namespace OpenSim.Modules.ContentDelivery
+{
+#region PHP Client
+    internal sealed class PhpAuthResponse
+    {
+        [JsonPropertyName("ok")]
+        public bool Ok { get; set; }
+
+        [JsonPropertyName("token")]
+        public string? Token { get; set; }
+
+        [JsonPropertyName("error_code")]
+        public string? ErrorCode { get; set; }
+
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+
+        [JsonPropertyName("correlation_id")]
+        public string? CorrelationId { get; set; }
+
+        [JsonPropertyName("expires_at")]
+        public DateTimeOffset? ExpiresAt { get; set; }
+    }
+
+    internal sealed class PhpAuthorizeResponse
+    {
+        [JsonPropertyName("ok")]
+        public bool Ok { get; set; }
+
+        [JsonPropertyName("error_code")]
+        public string? ErrorCode { get; set; }
+
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+
+        [JsonPropertyName("correlation_id")]
+        public string? CorrelationId { get; set; }
+
+        [JsonPropertyName("content_type")]
+        public string? ContentType { get; set; }
+
+        [JsonPropertyName("binary")]
+        public byte[]? Binary { get; set; }
+
+        [JsonPropertyName("url")]
+        public string? Url { get; set; }
+
+        [JsonPropertyName("metadata")]
+        public JsonElement Metadata { get; set; }
+    }
+
+    internal interface IHttpClient : IDisposable
+    {
+        Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken);
+    }
+
+    internal sealed class HttpClientWrapper : IHttpClient
+    {
+        private readonly HttpClient _client;
+        private bool _disposed;
+
+        public HttpClientWrapper(HttpClient client)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _client.SendAsync(request, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _client.Dispose();
+            _disposed = true;
+        }
+    }
+
+    internal sealed class PhpApiClient : IDisposable
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        private readonly ILog _log = LogManager.GetLogger("UuPwContentDelivery.PhpApiClient");
+        private readonly UuidPasswordContentDeliveryConfig _config;
+        private readonly IHttpClient _httpClient;
+        private readonly Uri _authEndpoint;
+        private readonly Uri _authorizeEndpoint;
+        private readonly Uri _downloadEndpoint;
+        private bool _disposed;
+
+        public PhpApiClient(UuidPasswordContentDeliveryConfig config)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+            var handler = new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip
+            };
+            var httpClient = new HttpClient(handler)
+            {
+                Timeout = TimeSpan.FromMilliseconds(_config.RequestTimeoutMs)
+            };
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("OpenSim-ContentDelivery/1.0");
+            _httpClient = new HttpClientWrapper(httpClient);
+            _authEndpoint = new Uri(_config.PhpApiBaseUrl, "/api/auth");
+            _authorizeEndpoint = new Uri(_config.PhpApiBaseUrl, "/api/authorize");
+            _downloadEndpoint = new Uri(_config.PhpApiBaseUrl, "/api/download");
+        }
+
+        internal PhpApiClient(UuidPasswordContentDeliveryConfig config, IHttpClient client)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+            _httpClient = client ?? throw new ArgumentNullException(nameof(client));
+            _authEndpoint = new Uri(_config.PhpApiBaseUrl, "/api/auth");
+            _authorizeEndpoint = new Uri(_config.PhpApiBaseUrl, "/api/authorize");
+            _downloadEndpoint = new Uri(_config.PhpApiBaseUrl, "/api/download");
+        }
+
+        public async Task<PhpAuthResponse> AuthenticateAsync(string avatarUuid, string password, CancellationToken cancellationToken, string? correlationId = null)
+        {
+            var payload = new Dictionary<string, object>
+            {
+                ["avatar_uuid"] = avatarUuid,
+                ["password"] = password
+            };
+            return await SendAsync<PhpAuthResponse>(_authEndpoint, payload, cancellationToken, correlationId).ConfigureAwait(false);
+        }
+
+        public async Task<PhpAuthorizeResponse> AuthorizeAsync(string token, string request, string id, CancellationToken cancellationToken, string? correlationId = null)
+        {
+            var payload = new Dictionary<string, object>
+            {
+                ["token"] = token,
+                ["request"] = request,
+                ["id"] = id
+            };
+            return await SendAsync<PhpAuthorizeResponse>(_authorizeEndpoint, payload, cancellationToken, correlationId).ConfigureAwait(false);
+        }
+
+        public async Task<HttpResponseMessage> DownloadAsync(string signedUrl, CancellationToken cancellationToken)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, signedUrl);
+            if (!string.IsNullOrEmpty(_config.SharedSecret))
+            {
+                request.Headers.TryAddWithoutValidation("X-Shared-Secret", _config.SharedSecret);
+            }
+
+            return await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<T> SendAsync<T>(Uri endpoint, IReadOnlyDictionary<string, object> payload, CancellationToken cancellationToken, string? correlationId)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(PhpApiClient));
+            }
+
+            for (var attempt = 0; ; attempt++)
+            {
+                try
+                {
+                    using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+                    {
+                        Content = new StringContent(JsonSerializer.Serialize(payload, SerializerOptions), Encoding.UTF8, "application/json")
+                    };
+
+                    if (!string.IsNullOrEmpty(_config.SharedSecret))
+                    {
+                        request.Headers.TryAddWithoutValidation("X-Shared-Secret", _config.SharedSecret);
+                    }
+
+                    if (!string.IsNullOrEmpty(correlationId))
+                    {
+                        request.Headers.TryAddWithoutValidation("X-Correlation-Id", correlationId);
+                    }
+
+                    using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        _log.WarnFormat("PHP API returned {0} with payload {1}", response.StatusCode, content);
+                    }
+
+                    return JsonSerializer.Deserialize<T>(content, SerializerOptions)
+                           ?? throw new InvalidOperationException("Unable to deserialize PHP API response");
+                }
+                catch (HttpRequestException ex) when (attempt < _config.MaxRetries)
+                {
+                    var delay = CalculateDelay(attempt);
+                    _log.WarnFormat("HTTP request failed ({0}). Retrying in {1}ms", ex.Message, delay);
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+                catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested && attempt < _config.MaxRetries)
+                {
+                    var delay = CalculateDelay(attempt);
+                    _log.WarnFormat("HTTP request timed out. Retrying in {0}ms", delay);
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private TimeSpan CalculateDelay(int attempt)
+        {
+            var ms = (int)(_config.RateLimitBackoffMs * Math.Pow(2, attempt));
+            return TimeSpan.FromMilliseconds(ms);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _httpClient.Dispose();
+            _disposed = true;
+        }
+    }
+
+#endregion
+}

--- a/opensim/UuidPasswordContentDeliveryModule.cs
+++ b/opensim/UuidPasswordContentDeliveryModule.cs
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using log4net;
+using OpenMetaverse;
+using OpenSim.Framework;
+using OpenSim.Framework.Servers.HttpServer;
+using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Region.Framework.Scenes;
+
+namespace OpenSim.Modules.ContentDelivery
+{
+#region Config
+    /// <summary>
+    /// Module configuration as read from OpenSim.ini.
+    /// </summary>
+    internal sealed class UuidPasswordContentDeliveryConfig
+    {
+        private const string Section = "UuidPasswordContentDelivery";
+
+        public bool Enabled { get; init; }
+        public Uri PhpApiBaseUrl { get; init; } = new("https://localhost");
+        public string SharedSecret { get; init; } = string.Empty;
+        public int RequestTimeoutMs { get; init; } = 5000;
+        public int MaxRetries { get; init; } = 2;
+        public bool ProxyBinary { get; init; }
+        public int RateLimitBackoffMs { get; init; } = 500;
+        public string LoggingLevel { get; init; } = "INFO";
+
+        public static UuidPasswordContentDeliveryConfig From(IConfigSource source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            var config = source.Configs[Section];
+            if (config == null)
+            {
+                return new UuidPasswordContentDeliveryConfig { Enabled = false };
+            }
+
+            return new UuidPasswordContentDeliveryConfig
+            {
+                Enabled = config.GetBoolean("Enabled", false),
+                PhpApiBaseUrl = new Uri(config.GetString("PhpApiBaseUrl", "https://localhost")),
+                SharedSecret = config.GetString("SharedSecret", string.Empty),
+                RequestTimeoutMs = config.GetInt("RequestTimeoutMs", 5000),
+                MaxRetries = config.GetInt("MaxRetries", 2),
+                ProxyBinary = config.GetBoolean("ProxyBinary", false),
+                RateLimitBackoffMs = config.GetInt("RateLimitBackoffMs", 500),
+                LoggingLevel = config.GetString("LoggingLevel", "INFO")
+            };
+        }
+    }
+
+#region Config
+    /// <summary>
+    /// Strongly typed request payload from viewers.
+    /// </summary>
+    internal sealed class FetchRequest
+    {
+        [JsonPropertyName("avatar_uuid")]
+        public string AvatarUuid { get; set; } = string.Empty;
+
+        [JsonPropertyName("password")]
+        public string Password { get; set; } = string.Empty;
+
+        [JsonPropertyName("request")]
+        public string Request { get; set; } = string.Empty;
+
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+    }
+
+#endregion
+
+#region Error Handling
+    internal static class RequestValidator
+    {
+        private static readonly Guid EmptyGuid = Guid.Empty;
+
+        public static bool TryValidateFetch(FetchRequest payload, out string? error)
+        {
+            if (payload == null)
+            {
+                error = "invalid_payload";
+                return false;
+            }
+
+            if (!UUID.TryParse(payload.AvatarUuid, out var uuid) || uuid == EmptyGuid)
+            {
+                error = "invalid_uuid";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(payload.Password) || payload.Password.Length < 8)
+            {
+                error = "invalid_password";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(payload.Request))
+            {
+                error = "invalid_request";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(payload.Id))
+            {
+                error = "invalid_id";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+    }
+
+#endregion
+
+#region Init
+    public sealed class UuidPasswordContentDeliveryModule : ISharedRegionModule
+    {
+        private static readonly ILog Log = LogManager.GetLogger("UuPwContentDelivery.Module");
+        private readonly List<Scene> _scenes = new();
+        private UuidPasswordContentDeliveryConfig? _config;
+        private PhpApiClient? _phpClient;
+        private IHttpServer? _httpServer;
+        private bool _initialised;
+
+        public string Name => "UuidPasswordContentDeliveryModule";
+
+        public Type ReplaceableInterface => null!;
+
+        public void Initialise(IConfigSource source)
+        {
+            _config = UuidPasswordContentDeliveryConfig.From(source);
+            if (!_config.Enabled)
+            {
+                Log.Info("UuidPasswordContentDeliveryModule disabled via configuration.");
+                return;
+            }
+
+            _phpClient = new PhpApiClient(_config);
+            _initialised = true;
+            Log.Info("UuidPasswordContentDeliveryModule initialised.");
+        }
+
+        public void PostInitialise()
+        {
+        }
+
+        public void Close()
+        {
+            _phpClient?.Dispose();
+            _phpClient = null;
+            _initialised = false;
+        }
+
+        public void AddRegion(Scene scene)
+        {
+            if (!_initialised)
+            {
+                return;
+            }
+
+            if (scene == null) throw new ArgumentNullException(nameof(scene));
+            _scenes.Add(scene);
+            if (_httpServer == null)
+            {
+                _httpServer = scene.RequestModuleInterface<ISimulationBase>()?.GetHttpServer(0);
+            }
+
+            if (_httpServer == null)
+            {
+                Log.Error("Unable to acquire HTTP server for content delivery endpoint.");
+                return;
+            }
+
+            _httpServer.AddStreamHandler(new RestStreamHandler("POST", "/content-delivery/fetch", FetchHandler, "UuidPasswordContentDeliveryFetch"));
+            _httpServer.AddStreamHandler(new RestStreamHandler("POST", "/content-delivery/auth-check", HealthHandler, "UuidPasswordContentDeliveryAuth"));
+            Log.InfoFormat("Content delivery endpoints registered on region {0}", scene.RegionInfo.RegionName);
+        }
+
+        public void RemoveRegion(Scene scene)
+        {
+            _scenes.Remove(scene);
+        }
+
+        public void RegionLoaded(Scene scene)
+        {
+        }
+
+#endregion
+
+#region HTTP Handlers
+        private string HealthHandler(string path, Stream request, OSHttpRequest httpRequest, OSHttpResponse httpResponse)
+        {
+            if (!_initialised || _phpClient == null)
+            {
+                return Error(httpResponse, HttpStatusCode.ServiceUnavailable, "module_disabled", null);
+            }
+
+            httpResponse.StatusCode = (int)HttpStatusCode.OK;
+            return JsonSerializer.Serialize(new { ok = true });
+        }
+
+        private string FetchHandler(string path, Stream requestStream, OSHttpRequest httpRequest, OSHttpResponse httpResponse)
+        {
+            var correlationId = EnsureCorrelationId(httpRequest, httpResponse);
+            try
+            {
+                if (!_initialised || _phpClient == null)
+                {
+                    return Error(httpResponse, HttpStatusCode.ServiceUnavailable, "module_disabled", correlationId);
+                }
+
+                FetchRequest? payload;
+                using (var reader = new StreamReader(requestStream, Encoding.UTF8, leaveOpen: true))
+                {
+                    var body = reader.ReadToEnd();
+                    payload = JsonSerializer.Deserialize<FetchRequest>(body);
+                }
+
+                if (!RequestValidator.TryValidateFetch(payload!, out var error))
+                {
+                    Log.WarnFormat("[{0}] Invalid payload: {1}", correlationId, error);
+                    return Error(httpResponse, HttpStatusCode.BadRequest, error ?? "invalid_payload", correlationId);
+                }
+
+                var cts = CancellationTokenSource.CreateLinkedTokenSource(httpRequest.TimedOutToken);
+                cts.CancelAfter(TimeSpan.FromMilliseconds(_config!.RequestTimeoutMs));
+
+                return FetchInternalAsync(payload!, httpResponse, correlationId, cts.Token).GetAwaiter().GetResult();
+            }
+            catch (JsonException ex)
+            {
+                Log.WarnFormat("[{0}] Failed to parse request: {1}", correlationId, ex.Message);
+                return Error(httpResponse, HttpStatusCode.BadRequest, "invalid_json", correlationId);
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorFormat("[{0}] Unhandled exception: {1}", correlationId, ex);
+                return Error(httpResponse, HttpStatusCode.InternalServerError, "internal_error", correlationId);
+            }
+        }
+
+        private async Task<string> FetchInternalAsync(FetchRequest payload, OSHttpResponse httpResponse, string correlationId, CancellationToken cancellationToken)
+        {
+            if (_phpClient == null)
+            {
+                return Error(httpResponse, HttpStatusCode.ServiceUnavailable, "module_disabled", correlationId);
+            }
+
+            var auth = await _phpClient.AuthenticateAsync(payload.AvatarUuid, payload.Password, cancellationToken, correlationId).ConfigureAwait(false);
+            if (!auth.Ok || string.IsNullOrEmpty(auth.Token))
+            {
+                return Error(httpResponse, HttpStatusCode.Unauthorized, auth.ErrorCode ?? "auth_failed", correlationId, auth.Message);
+            }
+
+            var authz = await _phpClient.AuthorizeAsync(auth.Token, payload.Request, payload.Id, cancellationToken, correlationId).ConfigureAwait(false);
+            if (!authz.Ok)
+            {
+                var status = authz.ErrorCode switch
+                {
+                    "not_found" => HttpStatusCode.NotFound,
+                    "rate_limited" => (HttpStatusCode)429,
+                    "not_authorized" => HttpStatusCode.Forbidden,
+                    _ => HttpStatusCode.BadRequest
+                };
+
+                return Error(httpResponse, status, authz.ErrorCode ?? "authorization_failed", correlationId, authz.Message);
+            }
+
+            if (!string.IsNullOrEmpty(authz.Url))
+            {
+                if (_config!.ProxyBinary)
+                {
+                    return await ProxyBinaryAsync(authz.Url, httpResponse, correlationId, cancellationToken).ConfigureAwait(false);
+                }
+
+                httpResponse.StatusCode = (int)HttpStatusCode.Found;
+                httpResponse.RedirectLocation = authz.Url;
+                httpResponse.ContentType = "application/json";
+                return JsonSerializer.Serialize(new
+                {
+                    ok = true,
+                    url = authz.Url,
+                    metadata = authz.Metadata,
+                    correlation_id = correlationId
+                });
+            }
+
+            if (authz.Binary != null)
+            {
+                httpResponse.StatusCode = (int)HttpStatusCode.OK;
+                httpResponse.ContentType = authz.ContentType ?? "application/octet-stream";
+                httpResponse.RawBuffer = authz.Binary;
+                return string.Empty;
+            }
+
+            return Error(httpResponse, HttpStatusCode.BadGateway, "invalid_response", correlationId);
+        }
+
+        private async Task<string> ProxyBinaryAsync(string url, OSHttpResponse httpResponse, string correlationId, CancellationToken cancellationToken)
+        {
+            if (_phpClient == null)
+            {
+                return Error(httpResponse, HttpStatusCode.ServiceUnavailable, "module_disabled", correlationId);
+            }
+
+            try
+            {
+                using var response = await _phpClient.DownloadAsync(url, cancellationToken).ConfigureAwait(false);
+                var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+                httpResponse.StatusCode = (int)response.StatusCode;
+                httpResponse.ContentType = response.Content.Headers.ContentType?.ToString() ?? "application/octet-stream";
+                httpResponse.RawBuffer = bytes;
+                return string.Empty;
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorFormat("[{0}] Proxy download failed: {1}", correlationId, ex.Message);
+                return Error(httpResponse, HttpStatusCode.BadGateway, "proxy_failed", correlationId);
+            }
+        }
+
+#endregion
+
+#region Error Handling
+        private static string Error(OSHttpResponse response, HttpStatusCode status, string code, string? correlationId, string? message = null)
+        {
+            response.StatusCode = (int)status;
+            response.ContentType = "application/json";
+            var payload = new
+            {
+                ok = false,
+                error_code = code,
+                message = message ?? status.ToString(),
+                correlation_id = correlationId
+            };
+            return JsonSerializer.Serialize(payload);
+        }
+
+#endregion
+
+#region Logging
+        private static string EnsureCorrelationId(OSHttpRequest request, OSHttpResponse response)
+        {
+            var id = request.Headers["X-Correlation-Id"];
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                id = Guid.NewGuid().ToString();
+            }
+
+            response.AddHeader("X-Correlation-Id", id);
+            return id;
+        }
+    }
+
+#endregion
+}

--- a/opensim/UuidPasswordContentDeliveryModule.csproj
+++ b/opensim/UuidPasswordContentDeliveryModule.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="OpenMetaverseTypes" Version="0.9.3" />
+    <PackageReference Include="OpenSim.Framework" Version="0.9.3" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/php-app/.env.example
+++ b/php-app/.env.example
@@ -1,0 +1,14 @@
+APP_ENV=production
+APP_DEBUG=false
+APP_BASE_URL="https://example.com"
+DB_DSN="mysql:host=localhost;dbname=opensim"
+DB_USER="opensim"
+DB_PASS="secret"
+HMAC_SECRET="CHANGE_ME"
+SHARED_SECRET="CHANGE_ME_TOO"
+SIGNED_URL_TTL_SECONDS=600
+FORCE_HTTPS=true
+RATE_LIMIT_PER_MINUTE=60
+TOKEN_TTL_SECONDS=600
+DOWNLOAD_STRATEGY=signed_url
+STORAGE_BASE_PATH="/var/lib/opensim/assets"

--- a/php-app/composer.json
+++ b/php-app/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "opensim/content-delivery",
+    "description": "Content delivery backend for OpenSimulator UUID/password module",
+    "type": "project",
+    "require": {
+        "php": "^8.2",
+        "vlucas/phpdotenv": "^5.6"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/php-app/composer.lock
+++ b/php-app/composer.lock
@@ -1,0 +1,2164 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "78c7fd45a8c89db33df695c7ff2cf7d5",
+    "packages": [
+        {
+            "name": "graham-campbell/result-type",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/3ba905c11371512af9d9bdd27d99b782216b6945",
+                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-20T21:45:45+00:00"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25 || ^10.5.53 || ^11.5.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-21T11:53:16+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-23T08:48:59+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-02T08:10:11+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v5.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "graham-campbell/result-type": "^1.1.3",
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.3",
+                "symfony/polyfill-ctype": "^1.24",
+                "symfony/polyfill-mbstring": "^1.24",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-filter": "*",
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
+            },
+            "suggest": {
+                "ext-filter": "Required to use the boolean validator."
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "5.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://github.com/vlucas"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-30T23:37:27+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+            },
+            "time": "2025-08-13T20:13:15+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.58",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.4",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.58"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-28T12:04:46+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-07T05:25:07+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:36:25+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.2"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/php-app/phpunit.xml.dist
+++ b/php-app/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="ContentDelivery">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/php-app/public/index.php
+++ b/php-app/public/index.php
@@ -1,0 +1,189 @@
+<?php
+declare(strict_types=1);
+
+use App\Auth;
+use App\Authorize;
+use App\RateLimiter;
+use App\Signer;
+use App\Validator;
+use Dotenv\Dotenv;
+use InvalidArgumentException;
+use RuntimeException;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+if (file_exists(__DIR__ . '/../.env')) {
+    $dotenv = Dotenv::createImmutable(dirname(__DIR__));
+    $dotenv->load();
+}
+
+$forceHttps = filter_var($_ENV['FORCE_HTTPS'] ?? 'true', FILTER_VALIDATE_BOOL);
+if ($forceHttps) {
+    $isHttps = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+        || (($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https');
+    if (!$isHttps) {
+        jsonError(400, 'https_required', 'HTTPS is required for this endpoint');
+    }
+}
+
+$rateLimiter = new RateLimiter((int)($_ENV['RATE_LIMIT_PER_MINUTE'] ?? '60'));
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+try {
+    if ($path === '/api/auth' && $method === 'POST') {
+        $rateLimiter->assertWithinLimit('auth:' . clientKey());
+        requireSharedSecret();
+        $payload = decodeJsonBody();
+        Validator::ensureAuthPayload($payload);
+
+        $auth = new Auth();
+        $result = $auth->authenticate($payload['avatar_uuid'], $payload['password']);
+        jsonResponse($result, $result['ok'] ? 200 : 401);
+    }
+
+    if ($path === '/api/authorize' && $method === 'POST') {
+        $rateLimiter->assertWithinLimit('authorize:' . clientKey());
+        requireSharedSecret();
+        $payload = decodeJsonBody();
+        Validator::ensureAuthorizePayload($payload);
+
+        $authorize = new Authorize();
+        $result = $authorize->authorize($payload['token'], $payload['request'], $payload['id']);
+        $status = $result['ok'] ? 200 : mapErrorToStatus($result['error_code'] ?? 'internal');
+        jsonResponse($result, $status);
+    }
+
+    if ($path === '/api/download' && $method === 'GET') {
+        $rateLimiter->assertWithinLimit('download:' . clientKey());
+        $id = $_GET['id'] ?? '';
+        $sig = $_GET['sig'] ?? '';
+        $expires = isset($_GET['expires']) ? (int)$_GET['expires'] : 0;
+        if (!Validator::isUuid($id)) {
+            jsonError(400, 'invalid_id', 'The asset identifier is invalid');
+        }
+
+        if ($expires < time()) {
+            jsonError(403, 'url_expired', 'Download link expired');
+        }
+
+        $signer = new Signer($_ENV['HMAC_SECRET'] ?? '');
+        if (!$signer->isValidSignature($id, $expires, $sig)) {
+            jsonError(403, 'invalid_signature', 'Signature validation failed');
+        }
+
+        $authorize = new Authorize();
+        $download = $authorize->downloadAsset($id);
+        if (!($download['ok'] ?? false)) {
+            $code = $download['error_code'] ?? 'internal_error';
+            jsonError(mapErrorToStatus($code), $code, $download['message'] ?? 'Download failed');
+        }
+
+        header('Content-Type: ' . $download['content_type']);
+        header('Content-Disposition: attachment; filename="' . addslashes($download['filename']) . '"');
+        header('X-Correlation-Id: ' . correlationId());
+        readfile($download['path']);
+        exit;
+    }
+
+    jsonError(404, 'not_found', 'Unknown endpoint');
+} catch (InvalidArgumentException $e) {
+    jsonError(400, $e->getMessage(), 'Validation failed');
+} catch (RuntimeException $e) {
+    $code = $e->getMessage();
+    if ($code === 'rate_limited') {
+        jsonError(429, 'rate_limited', 'Rate limit exceeded');
+    }
+
+    jsonError(mapErrorToStatus($code), $code, 'Request rejected');
+} catch (Throwable $e) {
+    $debug = filter_var($_ENV['APP_DEBUG'] ?? 'false', FILTER_VALIDATE_BOOL);
+    $message = $debug ? $e->getMessage() : 'Server error';
+    jsonError(500, 'internal_error', $message, $e->getCode(), $e);
+}
+
+function decodeJsonBody(): array
+{
+    $body = (string)file_get_contents('php://input');
+    if ($body === '') {
+        return [];
+    }
+
+    $data = json_decode($body, true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        jsonError(400, 'invalid_json', 'Malformed JSON body');
+    }
+
+    return $data ?? [];
+}
+
+function clientKey(): string
+{
+    $addr = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+    return (string)$addr;
+}
+
+function requireSharedSecret(): void
+{
+    $expected = $_ENV['SHARED_SECRET'] ?? '';
+    if ($expected === '') {
+        return;
+    }
+
+    $provided = $_SERVER['HTTP_X_SHARED_SECRET'] ?? '';
+    if ($provided === '' || !hash_equals($expected, $provided)) {
+        jsonError(401, 'auth_failed', 'Shared secret mismatch');
+    }
+}
+
+function mapErrorToStatus(string $code): int
+{
+    return match ($code) {
+        'invalid_payload', 'invalid_request', 'invalid_id', 'invalid_uuid', 'invalid_password' => 400,
+        'auth_failed' => 401,
+        'not_authorized' => 403,
+        'not_found' => 404,
+        'rate_limited' => 429,
+        default => 400,
+    };
+}
+
+function jsonResponse(array $data, int $status): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json');
+    header('X-Correlation-Id: ' . correlationId());
+    echo json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function jsonError(int $status, string $code, string $message, int $internalCode = 0, ?Throwable $throwable = null): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json');
+    header('X-Correlation-Id: ' . correlationId());
+    $payload = [
+        'ok' => false,
+        'error_code' => $code,
+        'message' => $message,
+        'correlation_id' => correlationId(),
+    ];
+
+    if ($throwable !== null && filter_var($_ENV['APP_DEBUG'] ?? 'false', FILTER_VALIDATE_BOOL)) {
+        $payload['trace'] = $throwable->getTraceAsString();
+    }
+
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function correlationId(): string
+{
+    static $id = null;
+    if ($id === null) {
+        $headerId = $_SERVER['HTTP_X_CORRELATION_ID'] ?? '';
+        $id = $headerId !== '' ? $headerId : bin2hex(random_bytes(8));
+    }
+
+    return $id;
+}

--- a/php-app/src/Auth.php
+++ b/php-app/src/Auth.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+use DateInterval;
+use DateTimeImmutable;
+use PDO;
+
+final class Auth
+{
+    private const DUMMY_HASH = '$argon2id$v=19$m=65536,t=4,p=1$w6uJ9wH14r2raXIiQun7pA$qls9B0xOSq2zu60zJtWWUw';
+
+    private Db $db;
+    private int $tokenTtl;
+    private int|string $passwordAlgo;
+
+    public function __construct(?Db $db = null)
+    {
+        $this->db = $db ?? new Db();
+        $this->tokenTtl = max(60, (int)($_ENV['TOKEN_TTL_SECONDS'] ?? '600'));
+        $this->passwordAlgo = \defined('PASSWORD_ARGON2ID') ? \PASSWORD_ARGON2ID : PASSWORD_DEFAULT;
+    }
+
+    public function authenticate(string $avatarUuid, string $password): array
+    {
+        Validator::assertPassword($password);
+        if (!Validator::isUuid($avatarUuid)) {
+            return $this->error('invalid_uuid', 'Invalid avatar identifier');
+        }
+
+        $pdo = $this->db->pdo();
+        $stmt = $pdo->prepare('SELECT id, password_hash FROM users WHERE avatar_uuid = :uuid LIMIT 1');
+        $stmt->execute(['uuid' => $avatarUuid]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        $hash = $row['password_hash'] ?? self::DUMMY_HASH;
+        $valid = password_verify($password, $hash);
+        if ($valid && isset($row['id'])) {
+            if (password_needs_rehash($hash, $this->passwordAlgo)) {
+                $newHash = password_hash($password, $this->passwordAlgo);
+                $update = $pdo->prepare('UPDATE users SET password_hash = :hash WHERE id = :id');
+                $update->execute(['hash' => $newHash, 'id' => $row['id']]);
+            }
+
+            [$token, $expiresAt] = $this->issueToken((int)$row['id']);
+            return [
+                'ok' => true,
+                'token' => $token,
+                'expires_at' => $expiresAt->format(DATE_ATOM),
+                'correlation_id' => $_SERVER['HTTP_X_CORRELATION_ID'] ?? null,
+            ];
+        }
+
+        // Delay to mitigate brute force attempts.
+        usleep(50000);
+        return $this->error('auth_failed', 'Authentication failed');
+    }
+
+    private function issueToken(int $userId): array
+    {
+        $token = bin2hex(random_bytes(32));
+        $expires = (new DateTimeImmutable('now'))->add(new DateInterval('PT' . $this->tokenTtl . 'S'));
+
+        $stmt = $this->db->pdo()->prepare('INSERT INTO auth_tokens (token, user_id, expires_at, created_at) VALUES (:token, :user_id, :expires_at, CURRENT_TIMESTAMP)');
+        $stmt->execute([
+            'token' => hash('sha256', $token),
+            'user_id' => $userId,
+            'expires_at' => $expires->format('Y-m-d H:i:s'),
+        ]);
+
+        return [$token, $expires];
+    }
+
+    private function error(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'error_code' => $code,
+            'message' => $message,
+            'correlation_id' => $_SERVER['HTTP_X_CORRELATION_ID'] ?? null,
+        ];
+    }
+}

--- a/php-app/src/Authorize.php
+++ b/php-app/src/Authorize.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+use DateInterval;
+use DateTimeImmutable;
+use PDO;
+use RuntimeException;
+
+final class Authorize
+{
+    private Db $db;
+    private Signer $signer;
+    private int $signedUrlTtl;
+    private string $strategy;
+    private string $storageBasePath;
+
+    public function __construct(?Db $db = null, ?Signer $signer = null)
+    {
+        $this->db = $db ?? new Db();
+        $secret = $_ENV['HMAC_SECRET'] ?? '';
+        $this->signer = $signer ?? new Signer($secret);
+        $this->signedUrlTtl = max(300, (int)($_ENV['SIGNED_URL_TTL_SECONDS'] ?? '600'));
+        $this->strategy = strtolower($_ENV['DOWNLOAD_STRATEGY'] ?? 'signed_url');
+        $this->storageBasePath = rtrim($_ENV['STORAGE_BASE_PATH'] ?? '', '/');
+    }
+
+    public function authorize(string $token, string $request, string $id): array
+    {
+        if (!Validator::isUuid($id)) {
+            return $this->error('invalid_id', 'Invalid identifier supplied');
+        }
+
+        Validator::assertRequest($request);
+
+        $tokenRecord = $this->lookupToken($token);
+        if ($tokenRecord === null) {
+            return $this->error('auth_failed', 'Authentication token is invalid or expired');
+        }
+
+        return match ($request) {
+            'asset', 'package' => $this->authorizeAsset((int)$tokenRecord['user_id'], $id),
+            'inventory' => $this->authorizeInventory((int)$tokenRecord['user_id']),
+            default => $this->error('invalid_request', 'Unsupported request type'),
+        };
+    }
+
+    public function downloadAsset(string $id): array
+    {
+        $pdo = $this->db->pdo();
+        $stmt = $pdo->prepare('SELECT id, type, location, content_type, filename FROM assets WHERE id = :id LIMIT 1');
+        $stmt->execute(['id' => $id]);
+        $asset = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$asset) {
+            return $this->error('not_found', 'Asset not found');
+        }
+
+        $path = $this->resolveLocation($asset['location']);
+        if (!is_readable($path)) {
+            return $this->error('not_found', 'Asset content missing');
+        }
+
+        $contentType = $asset['content_type'] ?: (mime_content_type($path) ?: 'application/octet-stream');
+        return [
+            'ok' => true,
+            'path' => $path,
+            'content_type' => $contentType,
+            'filename' => $asset['filename'] ?? basename($path),
+        ];
+    }
+
+    private function authorizeAsset(int $userId, string $assetId): array
+    {
+        $pdo = $this->db->pdo();
+        $stmt = $pdo->prepare('SELECT a.id, a.type, a.location, a.content_type, a.filename FROM assets a INNER JOIN permissions p ON p.asset_id = a.id WHERE p.user_id = :user AND a.id = :asset LIMIT 1');
+        $stmt->execute(['user' => $userId, 'asset' => $assetId]);
+        $asset = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$asset) {
+            return $this->error('not_authorized', 'Access denied or asset not found');
+        }
+
+        $metadata = [
+            'id' => $asset['id'],
+            'type' => $asset['type'],
+            'filename' => $asset['filename'],
+        ];
+
+        if ($this->strategy === 'inline') {
+            $path = $this->resolveLocation($asset['location']);
+            if (!is_readable($path)) {
+                return $this->error('not_found', 'Asset not found on storage');
+            }
+
+            $binary = base64_encode((string)file_get_contents($path));
+            return [
+                'ok' => true,
+                'content_type' => $asset['content_type'] ?: (mime_content_type($path) ?: 'application/octet-stream'),
+                'binary' => $binary,
+                'metadata' => $metadata,
+                'correlation_id' => $_SERVER['HTTP_X_CORRELATION_ID'] ?? null,
+            ];
+        }
+
+        $expires = (new DateTimeImmutable('now'))->add(new DateInterval('PT' . $this->signedUrlTtl . 'S'));
+        $signature = $this->signer->sign($asset['id'], $expires->getTimestamp());
+        $baseUrl = rtrim($_ENV['APP_BASE_URL'] ?? inferBaseUrl(), '/');
+        $url = sprintf('%s/api/download?id=%s&expires=%d&sig=%s', $baseUrl, rawurlencode($asset['id']), $expires->getTimestamp(), $signature);
+
+        return [
+            'ok' => true,
+            'url' => $url,
+            'metadata' => $metadata,
+            'correlation_id' => $_SERVER['HTTP_X_CORRELATION_ID'] ?? null,
+        ];
+    }
+
+    private function authorizeInventory(int $userId): array
+    {
+        $pdo = $this->db->pdo();
+        $stmt = $pdo->prepare('SELECT a.id, a.type, a.filename FROM assets a INNER JOIN permissions p ON p.asset_id = a.id WHERE p.user_id = :user ORDER BY a.filename');
+        $stmt->execute(['user' => $userId]);
+        $assets = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return [
+            'ok' => true,
+            'metadata' => [
+                'assets' => $assets,
+                'count' => count($assets),
+            ],
+            'correlation_id' => $_SERVER['HTTP_X_CORRELATION_ID'] ?? null,
+        ];
+    }
+
+    private function lookupToken(string $token): ?array
+    {
+        $hashed = hash('sha256', $token);
+        $stmt = $this->db->pdo()->prepare('SELECT user_id, expires_at FROM auth_tokens WHERE token = :token LIMIT 1');
+        $stmt->execute(['token' => $hashed]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row) {
+            return null;
+        }
+
+        $expires = new DateTimeImmutable($row['expires_at']);
+        if ($expires < new DateTimeImmutable('now')) {
+            $delete = $this->db->pdo()->prepare('DELETE FROM auth_tokens WHERE token = :token');
+            $delete->execute(['token' => $hashed]);
+            return null;
+        }
+
+        return $row;
+    }
+
+    private function resolveLocation(string $location): string
+    {
+        $path = str_starts_with($location, 'file://') ? substr($location, 7) : $location;
+        if ($this->storageBasePath !== '' && !str_starts_with($path, $this->storageBasePath)) {
+            $path = $this->storageBasePath . '/' . ltrim($path, '/');
+        }
+
+        $real = realpath($path);
+        if ($real === false) {
+            return $path;
+        }
+
+        if ($this->storageBasePath !== '' && !str_starts_with($real, $this->storageBasePath)) {
+            throw new RuntimeException('not_authorized');
+        }
+
+        return $real;
+    }
+
+    private function error(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'error_code' => $code,
+            'message' => $message,
+            'correlation_id' => $_SERVER['HTTP_X_CORRELATION_ID'] ?? null,
+        ];
+    }
+}
+
+function inferBaseUrl(): string
+{
+    $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    return sprintf('%s://%s', $scheme, $host);
+}

--- a/php-app/src/Db.php
+++ b/php-app/src/Db.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+use PDO;
+use PDOException;
+
+final class Db
+{
+    private PDO $pdo;
+
+    public function __construct(?PDO $pdo = null)
+    {
+        if ($pdo instanceof PDO) {
+            $this->pdo = $pdo;
+            return;
+        }
+
+        $dsn = $_ENV['DB_DSN'] ?? '';
+        $user = $_ENV['DB_USER'] ?? '';
+        $pass = $_ENV['DB_PASS'] ?? '';
+
+        if ($dsn === '') {
+            throw new PDOException('DB_DSN environment variable is required');
+        }
+
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ];
+
+        $this->pdo = new PDO($dsn, $user, $pass, $options);
+    }
+
+    public function pdo(): PDO
+    {
+        return $this->pdo;
+    }
+}

--- a/php-app/src/RateLimiter.php
+++ b/php-app/src/RateLimiter.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+use RuntimeException;
+
+final class RateLimiter
+{
+    private int $limitPerMinute;
+    private string $storageDir;
+
+    public function __construct(int $limitPerMinute)
+    {
+        if ($limitPerMinute <= 0) {
+            throw new RuntimeException('Rate limit must be positive');
+        }
+
+        $this->limitPerMinute = $limitPerMinute;
+        $this->storageDir = sys_get_temp_dir() . '/content-rate';
+        if (!is_dir($this->storageDir) && !mkdir($this->storageDir, 0770, true) && !is_dir($this->storageDir)) {
+            throw new RuntimeException('Unable to initialise rate limiter storage');
+        }
+    }
+
+    public function assertWithinLimit(string $key): void
+    {
+        $bucket = $this->storageDir . '/' . sha1($key);
+        $now = time();
+        $windowStart = $now - 60;
+
+        $entries = [];
+        if (file_exists($bucket)) {
+            $raw = file_get_contents($bucket);
+            $entries = $raw ? array_filter(array_map('intval', explode('\n', trim($raw)))) : [];
+        }
+
+        $entries = array_filter($entries, static fn(int $ts) => $ts >= $windowStart);
+        if (count($entries) >= $this->limitPerMinute) {
+            throw new RuntimeException('rate_limited');
+        }
+
+        $entries[] = $now;
+        file_put_contents($bucket, implode("\n", $entries), LOCK_EX);
+    }
+}

--- a/php-app/src/Signer.php
+++ b/php-app/src/Signer.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+use RuntimeException;
+
+final class Signer
+{
+    private string $secret;
+
+    public function __construct(string $secret)
+    {
+        if ($secret === '') {
+            throw new RuntimeException('HMAC secret must not be empty');
+        }
+
+        $this->secret = $secret;
+    }
+
+    public function sign(string $id, int $expiresAt): string
+    {
+        return hash_hmac('sha256', $id . ':' . $expiresAt, $this->secret);
+    }
+
+    public function isValidSignature(string $id, int $expiresAt, string $signature): bool
+    {
+        if ($signature === '') {
+            return false;
+        }
+
+        $expected = $this->sign($id, $expiresAt);
+        return hash_equals($expected, $signature);
+    }
+}

--- a/php-app/src/Validator.php
+++ b/php-app/src/Validator.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+use InvalidArgumentException;
+
+final class Validator
+{
+    private const UUID_REGEX = '/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/';
+    private const REQUEST_TYPES = ['asset', 'inventory', 'package'];
+
+    public static function ensureAuthPayload(array $payload): void
+    {
+        if (!isset($payload['avatar_uuid'], $payload['password'])) {
+            throw new InvalidArgumentException('invalid_payload');
+        }
+
+        if (!self::isUuid((string)$payload['avatar_uuid'])) {
+            throw new InvalidArgumentException('invalid_uuid');
+        }
+
+        self::assertPassword((string)$payload['password']);
+    }
+
+    public static function ensureAuthorizePayload(array $payload): void
+    {
+        if (!isset($payload['token'], $payload['request'], $payload['id'])) {
+            throw new InvalidArgumentException('invalid_payload');
+        }
+
+        if (!is_string($payload['token']) || $payload['token'] === '') {
+            throw new InvalidArgumentException('auth_failed');
+        }
+
+        self::assertRequest((string)$payload['request']);
+
+        if (!self::isUuid((string)$payload['id'])) {
+            throw new InvalidArgumentException('invalid_id');
+        }
+    }
+
+    public static function isUuid(string $value): bool
+    {
+        return (bool)preg_match(self::UUID_REGEX, $value);
+    }
+
+    public static function assertPassword(string $password): void
+    {
+        if (strlen($password) < 8) {
+            throw new InvalidArgumentException('invalid_password');
+        }
+    }
+
+    public static function assertRequest(string $request): void
+    {
+        if (!in_array($request, self::REQUEST_TYPES, true)) {
+            throw new InvalidArgumentException('invalid_request');
+        }
+    }
+}

--- a/php-app/tests/AuthTest.php
+++ b/php-app/tests/AuthTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use App\Auth;
+use App\Db;
+
+final class AuthTest extends TestCase
+{
+    public function testAuthenticateIssuesToken(): void
+    {
+        $_SERVER['HTTP_X_CORRELATION_ID'] = 'test-correlation';
+        $algo = \defined('PASSWORD_ARGON2ID') ? \PASSWORD_ARGON2ID : PASSWORD_DEFAULT;
+        $hash = password_hash('Password123!', $algo);
+        $stmt = $this->pdo->prepare('INSERT INTO users (avatar_uuid, password_hash) VALUES (:uuid, :hash)');
+        $stmt->execute([
+            'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'hash' => $hash,
+        ]);
+
+        $auth = new Auth(new Db($this->pdo));
+        $result = $auth->authenticate('123e4567-e89b-12d3-a456-426614174000', 'Password123!');
+
+        self::assertTrue($result['ok']);
+        self::assertArrayHasKey('token', $result);
+        self::assertSame('test-correlation', $result['correlation_id']);
+
+        $count = (int)$this->pdo->query('SELECT COUNT(*) FROM auth_tokens')->fetchColumn();
+        self::assertSame(1, $count);
+    }
+}

--- a/php-app/tests/AuthorizeTest.php
+++ b/php-app/tests/AuthorizeTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use App\Authorize;
+use App\Db;
+use App\Signer;
+
+final class AuthorizeTest extends TestCase
+{
+    public function testAuthorizeReturnsSignedUrl(): void
+    {
+        $_SERVER['HTTP_X_CORRELATION_ID'] = 'corr';
+        $_ENV['STORAGE_BASE_PATH'] = sys_get_temp_dir();
+        $_ENV['DOWNLOAD_STRATEGY'] = 'signed_url';
+
+        $assetPath = sys_get_temp_dir() . '/asset.bin';
+        file_put_contents($assetPath, 'demo-data');
+
+        $algo = \defined('PASSWORD_ARGON2ID') ? \PASSWORD_ARGON2ID : PASSWORD_DEFAULT;
+        $this->pdo->prepare('INSERT INTO users (id, avatar_uuid, password_hash) VALUES (1, :uuid, :hash)')->execute([
+            'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'hash' => password_hash('Password123!', $algo),
+        ]);
+
+        $this->pdo->prepare('INSERT INTO assets (id, type, location, content_type, filename) VALUES (:id, :type, :location, :content_type, :filename)')->execute([
+            'id' => '123e4567-e89b-12d3-a456-426614174001',
+            'type' => 'texture',
+            'location' => $assetPath,
+            'content_type' => 'application/octet-stream',
+            'filename' => 'asset.bin',
+        ]);
+
+        $this->pdo->prepare('INSERT INTO permissions (user_id, asset_id, can_fetch) VALUES (1, :asset, 1)')->execute([
+            'asset' => '123e4567-e89b-12d3-a456-426614174001',
+        ]);
+
+        $token = 'sampletoken';
+        $this->pdo->prepare('INSERT INTO auth_tokens (token, user_id, expires_at) VALUES (:token, 1, :expires)')->execute([
+            'token' => hash('sha256', $token),
+            'expires' => (new \DateTimeImmutable('+10 minutes'))->format('Y-m-d H:i:s'),
+        ]);
+
+        $authorize = new Authorize(new Db($this->pdo), new Signer('test-secret'));
+        $result = $authorize->authorize($token, 'asset', '123e4567-e89b-12d3-a456-426614174001');
+
+        self::assertTrue($result['ok']);
+        self::assertArrayHasKey('url', $result);
+        self::assertStringContainsString('/api/download', $result['url']);
+    }
+}

--- a/php-app/tests/SignerTest.php
+++ b/php-app/tests/SignerTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use App\Signer;
+
+final class SignerTest extends TestCase
+{
+    public function testSignatureRoundTrip(): void
+    {
+        $signer = new Signer('secret');
+        $expires = time() + 600;
+        $sig = $signer->sign('123e4567-e89b-12d3-a456-426614174000', $expires);
+
+        self::assertTrue($signer->isValidSignature('123e4567-e89b-12d3-a456-426614174000', $expires, $sig));
+        self::assertFalse($signer->isValidSignature('123e4567-e89b-12d3-a456-426614174001', $expires, $sig));
+    }
+}

--- a/php-app/tests/TestCase.php
+++ b/php-app/tests/TestCase.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use PDO;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected PDO $pdo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        $this->createSchema();
+    }
+
+    private function createSchema(): void
+    {
+        $this->pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, avatar_uuid TEXT UNIQUE, password_hash TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP)');
+        $this->pdo->exec('CREATE TABLE assets (id TEXT PRIMARY KEY, type TEXT, location TEXT, content_type TEXT, filename TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP)');
+        $this->pdo->exec('CREATE TABLE permissions (user_id INTEGER, asset_id TEXT, can_fetch INTEGER DEFAULT 1, PRIMARY KEY (user_id, asset_id))');
+        $this->pdo->exec('CREATE TABLE auth_tokens (token TEXT PRIMARY KEY, user_id INTEGER, expires_at TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP)');
+    }
+}

--- a/php-app/tests/ValidatorTest.php
+++ b/php-app/tests/ValidatorTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use App\Validator;
+use InvalidArgumentException;
+
+final class ValidatorTest extends TestCase
+{
+    public function testEnsureAuthPayloadValid(): void
+    {
+        $payload = [
+            'avatar_uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'password' => 'correcthorsebattery',
+        ];
+
+        Validator::ensureAuthPayload($payload);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEnsureAuthPayloadInvalidUuid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid_uuid');
+        Validator::ensureAuthPayload([
+            'avatar_uuid' => 'bad',
+            'password' => 'password123',
+        ]);
+    }
+}

--- a/php-app/tests/bootstrap.php
+++ b/php-app/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$_ENV['HMAC_SECRET'] = $_ENV['HMAC_SECRET'] ?? 'test-secret';
+$_ENV['SHARED_SECRET'] = $_ENV['SHARED_SECRET'] ?? 'shared-secret';
+$_ENV['SIGNED_URL_TTL_SECONDS'] = $_ENV['SIGNED_URL_TTL_SECONDS'] ?? '600';
+$_ENV['DOWNLOAD_STRATEGY'] = $_ENV['DOWNLOAD_STRATEGY'] ?? 'signed_url';
+$_ENV['APP_BASE_URL'] = $_ENV['APP_BASE_URL'] ?? 'https://example.test';
+$_ENV['TOKEN_TTL_SECONDS'] = $_ENV['TOKEN_TTL_SECONDS'] ?? '600';

--- a/tests/cs/PhpApiClientTests.cs
+++ b/tests/cs/PhpApiClientTests.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OpenSim.Modules.ContentDelivery;
+
+namespace UuidPasswordContentDeliveryModule.Tests
+{
+    public sealed class PhpApiClientTests
+    {
+        [Test]
+        public async Task AuthenticateAsync_AttachesSecretAndCorrelation()
+        {
+            var recordedHeaders = new Dictionary<string, string>();
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ok\":true,\"token\":\"abc\"}")
+            };
+            var httpClient = new RecordingHttpClient(_ => response, recordedHeaders);
+            var config = new UuidPasswordContentDeliveryConfig
+            {
+                PhpApiBaseUrl = new Uri("https://example.test"),
+                SharedSecret = "secret",
+                RequestTimeoutMs = 5000,
+                MaxRetries = 0,
+                RateLimitBackoffMs = 10
+            };
+
+            var client = new PhpApiClient(config, httpClient);
+            var result = await client.AuthenticateAsync(Guid.NewGuid().ToString(), "password123", CancellationToken.None, "corr-1");
+
+            Assert.IsTrue(result.Ok);
+            Assert.That(recordedHeaders["X-Shared-Secret"], Is.EqualTo("secret"));
+            Assert.That(recordedHeaders["X-Correlation-Id"], Is.EqualTo("corr-1"));
+        }
+
+        [Test]
+        public async Task AuthorizeAsync_RetriesOnTransientFailure()
+        {
+            var attempts = 0;
+            var httpClient = new RecordingHttpClient(request =>
+            {
+                if (attempts++ == 0)
+                {
+                    throw new HttpRequestException("boom");
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"ok\":true,\"url\":\"https://example.test/download\"}")
+                };
+            });
+
+            var config = new UuidPasswordContentDeliveryConfig
+            {
+                PhpApiBaseUrl = new Uri("https://example.test"),
+                SharedSecret = string.Empty,
+                MaxRetries = 1,
+                RateLimitBackoffMs = 1
+            };
+
+            var client = new PhpApiClient(config, httpClient);
+            var result = await client.AuthorizeAsync("token", "asset", "id", CancellationToken.None, "corr-2");
+
+            Assert.IsTrue(result.Ok);
+            Assert.That(attempts, Is.EqualTo(2));
+        }
+
+        private sealed class RecordingHttpClient : IHttpClient
+        {
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
+            private readonly IDictionary<string, string>? _headerSink;
+
+            public RecordingHttpClient(Func<HttpRequestMessage, HttpResponseMessage> responseFactory, IDictionary<string, string>? headerSink = null)
+            {
+                _responseFactory = responseFactory;
+                _headerSink = headerSink;
+            }
+
+            public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (_headerSink != null)
+                {
+                    foreach (var header in request.Headers)
+                    {
+                        _headerSink[header.Key] = string.Join(",", header.Value);
+                    }
+                }
+
+                var result = _responseFactory(request);
+                return Task.FromResult(result);
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/tests/cs/Stubs.cs
+++ b/tests/cs/Stubs.cs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace OpenMetaverse
+{
+    public readonly struct UUID : IEquatable<UUID>
+    {
+        private readonly Guid _value;
+
+        private UUID(Guid value)
+        {
+            _value = value;
+        }
+
+        public static bool TryParse(string? input, out UUID uuid)
+        {
+            if (Guid.TryParse(input, out var guid))
+            {
+                uuid = new UUID(guid);
+                return true;
+            }
+
+            uuid = default;
+            return false;
+        }
+
+        public bool Equals(UUID other) => _value.Equals(other._value);
+        public override bool Equals(object? obj) => obj is UUID other && Equals(other);
+        public override int GetHashCode() => _value.GetHashCode();
+        public static bool operator ==(UUID left, UUID right) => left.Equals(right);
+        public static bool operator !=(UUID left, UUID right) => !left.Equals(right);
+        public static implicit operator Guid(UUID uuid) => uuid._value;
+    }
+}
+
+namespace OpenSim.Framework
+{
+    public interface IConfig
+    {
+        bool GetBoolean(string key, bool defaultValue);
+        string GetString(string key, string defaultValue);
+        int GetInt(string key, int defaultValue);
+    }
+
+    public interface IConfigCollection
+    {
+        IConfig? this[string section] { get; }
+    }
+
+    public interface IConfigSource
+    {
+        IConfigCollection Configs { get; }
+    }
+
+    public sealed class OSHttpRequest
+    {
+        public Dictionary<string, string> Headers { get; } = new();
+        public CancellationToken TimedOutToken { get; set; } = CancellationToken.None;
+    }
+
+    public sealed class OSHttpResponse
+    {
+        public int StatusCode { get; set; }
+        public string ContentType { get; set; } = "application/json";
+        public string? RedirectLocation { get; set; }
+        public byte[]? RawBuffer { get; set; }
+
+        private readonly Dictionary<string, string> _headers = new();
+
+        public void AddHeader(string key, string value) => _headers[key] = value;
+    }
+}
+
+namespace OpenSim.Framework.Servers.HttpServer
+{
+    public interface IHttpServer
+    {
+        void AddStreamHandler(RestStreamHandler handler);
+    }
+
+    public sealed class RestStreamHandler
+    {
+        public RestStreamHandler(string method, string path, Func<string, System.IO.Stream, OpenSim.Framework.OSHttpRequest, OpenSim.Framework.OSHttpResponse, string> handler, string name)
+        {
+        }
+    }
+}
+
+namespace OpenSim.Region.Framework.Interfaces
+{
+    public interface ISimulationBase
+    {
+        OpenSim.Framework.Servers.HttpServer.IHttpServer? GetHttpServer(uint port);
+    }
+
+    public interface ISharedRegionModule
+    {
+        string Name { get; }
+        Type ReplaceableInterface { get; }
+        void Initialise(OpenSim.Framework.IConfigSource source);
+        void PostInitialise();
+        void Close();
+        void AddRegion(OpenSim.Region.Framework.Scenes.Scene scene);
+        void RemoveRegion(OpenSim.Region.Framework.Scenes.Scene scene);
+        void RegionLoaded(OpenSim.Region.Framework.Scenes.Scene scene);
+    }
+}
+
+namespace OpenSim.Region.Framework.Scenes
+{
+    public sealed class RegionInfo
+    {
+        public string RegionName { get; set; } = string.Empty;
+    }
+
+    public sealed class Scene
+    {
+        public RegionInfo RegionInfo { get; } = new();
+
+        public T? RequestModuleInterface<T>() where T : class
+        {
+            return null;
+        }
+    }
+}

--- a/tests/cs/TestConfig.cs
+++ b/tests/cs/TestConfig.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+using System;
+
+namespace OpenSim.Modules.ContentDelivery
+{
+    internal sealed class UuidPasswordContentDeliveryConfig
+    {
+        public bool Enabled { get; init; }
+        public Uri PhpApiBaseUrl { get; init; } = new("https://localhost");
+        public string SharedSecret { get; init; } = string.Empty;
+        public int RequestTimeoutMs { get; init; } = 5000;
+        public int MaxRetries { get; init; } = 2;
+        public bool ProxyBinary { get; init; }
+        public int RateLimitBackoffMs { get; init; } = 500;
+        public string LoggingLevel { get; init; } = "INFO";
+    }
+}

--- a/tests/cs/UuidPasswordContentDeliveryModule.Tests.csproj
+++ b/tests/cs/UuidPasswordContentDeliveryModule.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../opensim/PhpApiClient.cs" />
+    <Compile Include="Stubs.cs" />
+    <Compile Include="TestConfig.cs" />
+    <Compile Include="PhpApiClientTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="log4net" Version="2.0.15" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add `UuidPasswordContentDeliveryModule` shared region module with HTTP handlers, validation, and PHP API client
- implement PHP 8.2 backend (auth, authorize, download) with Argon2id hashing, signed URLs, rate limiting, and configuration assets
- provide database migration, environment samples, and automated tests for both C# client retries and PHP services

## Testing
- ✅ `composer install`
- ✅ `./vendor/bin/phpunit`
- ⚠️ `dotnet test tests/cs/UuidPasswordContentDeliveryModule.Tests.csproj` *(dotnet CLI unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dead50485883298e5bddad99411eee